### PR TITLE
[🐛 Fix] authorization token

### DIFF
--- a/src/routes/authRoute.js
+++ b/src/routes/authRoute.js
@@ -43,7 +43,7 @@ router.post(
 router.post(
 	'/recovery/password',
 	validatorHandler(recoveryPassword, 'body'),
-	passport.authenticate('jwt', { session: false }),
+	passport.authenticate('jwtRecovery', { session: false }),
 	async (req, res, next) => {
 		try {
 			const token = req.user;
@@ -56,7 +56,7 @@ router.post(
 );
 
 router.get('/recovery', (req, res, next) => {
-	passport.authenticate('jwt', { session: false }, (err, user) => {
+	passport.authenticate('jwtRecovery', { session: false }, (err, user) => {
 		if (err) {
 			next(err);
 		}

--- a/src/utils/auth/index.js
+++ b/src/utils/auth/index.js
@@ -4,4 +4,4 @@ const { jwtStrategy, jwtStrategyRecov } = require('./strategies/passportJWT');
 
 passport.use(localStrategy);
 passport.use(jwtStrategy);
-passport.use(jwtStrategyRecov);
+passport.use('jwtRecovery', jwtStrategyRecov);


### PR DESCRIPTION
Now all password recovery endpoints require authorization via query.

I changed the authentication strategy to improve clarity and consistency in the project. This will ensure that users can reset their passwords safely and efficiently.